### PR TITLE
Parse message with multiple lines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
     <dependency>
       <groupId>com.github.tony19</groupId>
       <artifactId>named-regexp</artifactId>
-      <version>0.1.9</version>
+      <version>0.2.4</version>
     </dependency>
 
   </dependencies>

--- a/src/main/java/ch/qos/logback/decoder/Decoder.java
+++ b/src/main/java/ch/qos/logback/decoder/Decoder.java
@@ -52,7 +52,7 @@ public abstract class Decoder {
    */
   public void setLayoutPattern(String layoutPattern) {
     if (layoutPattern != null) {
-      String regex = new PatternLayoutRegexUtil().toRegex(layoutPattern);
+      String regex = new PatternLayoutRegexUtil().toRegex(layoutPattern) + "$";
       regexPattern = Pattern.compile(regex);
       patternInfo = PatternParser.parse(layoutPattern);
     } else {

--- a/src/test/java/ch/qos/logback/decoder/MessageDecoderTest.java
+++ b/src/test/java/ch/qos/logback/decoder/MessageDecoderTest.java
@@ -12,10 +12,12 @@
  */
 package ch.qos.logback.decoder;
 
+import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import org.junit.Test;
+
 
 /**
  * Tests decoding %message
@@ -31,6 +33,11 @@ public class MessageDecoderTest extends DecoderTest {
   @Test
   public void decodesSimpleMessage() {
     assertEquals("This is just a test", getMessage("This is just a test"));
+  }
+
+  @Test
+  public void testMultiline() {
+    assertEquals("This\nis\ntest.", getMessage("This\nis\ntest."));
   }
 
   private String getMessage(String message) {


### PR DESCRIPTION
logback-parse doesn't capture a message with multiple lines correctly even though it uses DOTALL. `(?s).+?`

The issue is that it uses reluctant quantifiers `+?`, so if a regex is `{message}{newline}` (`(?s).+?(\r?\n)`), it stops matching once it finds a first newline char.

I'm fixing this by adding `$` at the end of regex, so that the last `{newline}` pattern only matches the newline char at the end of the string.

Also upgrading named-regexp to 0.2.4.


