### PR TITLE
Extract MDC property

### DIFF
--- a/src/main/java/ch/qos/logback/decoder/Decoder.java
+++ b/src/main/java/ch/qos/logback/decoder/Decoder.java
@@ -110,23 +110,19 @@ public abstract class Decoder {
               logger.warn("Cannot parse {} in {}", kv, field);
             }
           }
-          continue;
-        }
-
-        if (pattName.startsWith(PatternNames.MDC_PREFIX)) {
+        } else if (pattName.startsWith(PatternNames.MDC_PREFIX)) {
           String key = pattName.substring(PatternNames.MDC_PREFIX.length());
           if (mdcProperties == null) {
             mdcProperties = new HashMap<String, String>();
           }
           mdcProperties.put(key, field);
-          continue;
-        }
-
-        FieldCapturer<IStaticLoggingEvent> parser = DECODER_MAP.get(pattName);
-        if (parser == null) {
-          logger.warn("No decoder for [{}, {}]", pattName, field);
         } else {
-          parser.captureField(event, field, getPatternInfo(patternIndex, pattName));
+          FieldCapturer<IStaticLoggingEvent> parser = DECODER_MAP.get(pattName);
+          if (parser == null) {
+            logger.warn("No decoder for [{}, {}]", pattName, field);
+          } else {
+            parser.captureField(event, field, getPatternInfo(patternIndex, pattName));
+          }
         }
 
         patternIndex++;

--- a/src/main/java/ch/qos/logback/decoder/PatternNames.java
+++ b/src/main/java/ch/qos/logback/decoder/PatternNames.java
@@ -72,6 +72,7 @@ public class PatternNames {
   public static final String FILE_OF_CALLER_1 = "F";
   
   public static final String MDC = "mdc";
+  public static final String MDC_PREFIX = "mdc.";
   public static final String MDC_1 = "X";
   
   public static final String EXCEPTION = "exception";

--- a/src/main/java/ch/qos/logback/decoder/regex/MDCRegexConverter.java
+++ b/src/main/java/ch/qos/logback/decoder/regex/MDCRegexConverter.java
@@ -27,8 +27,8 @@ public class MDCRegexConverter extends DynamicConverter<InputStream> {
   @Override
   public void start() {
     key = getFirstOption();
-    if (key != null && key.indexOf(':') > 0) {
-      key = key.substring(key.indexOf((':') + 1));
+    if (key != null && key.indexOf(":-") > 0) {
+      key = key.substring(0, key.indexOf(":-"));
     }
   }
 

--- a/src/main/java/ch/qos/logback/decoder/regex/MDCRegexConverter.java
+++ b/src/main/java/ch/qos/logback/decoder/regex/MDCRegexConverter.java
@@ -14,6 +14,7 @@ package ch.qos.logback.decoder.regex;
 
 import java.io.InputStream;
 
+import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.pattern.DynamicConverter;
 import ch.qos.logback.decoder.PatternNames;
 
@@ -21,8 +22,22 @@ import ch.qos.logback.decoder.PatternNames;
  * Converts a MDC pattern into a regular expression
  */
 public class MDCRegexConverter extends DynamicConverter<InputStream> {
-  
+  private String key = null;
+
+  @Override
+  public void start() {
+    key = getFirstOption();
+    if (key != null && key.indexOf(':') > 0) {
+      key = key.substring(key.indexOf((':') + 1));
+    }
+  }
+
+  @Override
   public String convert(InputStream le) {
-    return "(?<" + PatternNames.MDC + ">" + RegexPatterns.MDC_REGEX + ")";
+    if (key == null) {
+      return "(?<" + PatternNames.MDC + ">" + RegexPatterns.MDC_REGEX + ")";
+    } else {
+      return "(?<" + PatternNames.MDC_PREFIX + key + ">" + RegexPatterns.Common.NON_WHITESPACE_REGEX + ")";
+    }
   }
 }

--- a/src/test/java/ch/qos/logback/decoder/MessageDecoderTest.java
+++ b/src/test/java/ch/qos/logback/decoder/MessageDecoderTest.java
@@ -12,6 +12,7 @@
  */
 package ch.qos.logback.decoder;
 
+import ch.qos.logback.classic.Level;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -38,6 +39,19 @@ public class MessageDecoderTest extends DecoderTest {
   @Test
   public void testMultiline() {
     assertEquals("This\nis\ntest.", getMessage("This\nis\ntest."));
+  }
+
+  @Test
+  public void testMDCProperties() {
+    String input = "20:44:20.120 [JGroups-Executor-17] INFO c._.u.s.xmpp.server.XMPPConnection SID:123abc CID:456xyz - START handlePresence(PbxUserPresence{extension='1234', message='', status=3, pbxId='customerABC', pnRegistered=false, timestamp=0})\n";
+    decoder.setLayoutPattern("%d{HH:mm:ss.SSS} [%thread] %-5level %logger{35} SID:%X{SID} CID:%X{CID} - %msg%n");
+    StaticLoggingEvent event = (StaticLoggingEvent)decoder.decode(input);
+    assertEquals("JGroups-Executor-17", event.getThreadName());
+    assertEquals(Level.INFO, event.getLevel());
+    assertEquals("c._.u.s.xmpp.server.XMPPConnection", event.getLoggerName());
+    assertEquals("START handlePresence(PbxUserPresence{extension='1234', message='', status=3, pbxId='customerABC', pnRegistered=false, timestamp=0})", event.getMessage());
+    assertEquals("123abc", event.getMDCPropertyMap().get("SID"));
+    assertEquals("456xyz", event.getMDCPropertyMap().get("CID"));
   }
 
   private String getMessage(String message) {

--- a/src/test/java/ch/qos/logback/decoder/MessageDecoderTest.java
+++ b/src/test/java/ch/qos/logback/decoder/MessageDecoderTest.java
@@ -52,6 +52,25 @@ public class MessageDecoderTest extends DecoderTest {
     assertEquals("START handlePresence(PbxUserPresence{extension='1234', message='', status=3, pbxId='customerABC', pnRegistered=false, timestamp=0})", event.getMessage());
     assertEquals("123abc", event.getMDCPropertyMap().get("SID"));
     assertEquals("456xyz", event.getMDCPropertyMap().get("CID"));
+
+    // pattern with default values
+    decoder.setLayoutPattern("%d{HH:mm:ss.SSS} [%thread] %-5level %logger{35} SID:%X{SID:-123} CID:%X{CID:-456} - %msg%n");
+    event = (StaticLoggingEvent)decoder.decode(input);
+    assertEquals("123abc", event.getMDCPropertyMap().get("SID"));
+    assertEquals("456xyz", event.getMDCPropertyMap().get("CID"));
+
+    // pattern without key
+    decoder.setLayoutPattern("%d{HH:mm:ss.SSS} [%thread] %-5level %logger{35} ID:%X - %msg%n");
+    input = "20:44:20.120 [JGroups-Executor-17] INFO c._.u.s.xmpp.server.XMPPConnection ID:SID=123abc,CID=456xyz - START handlePresence(PbxUserPresence{extension='1234', message='', status=3, pbxId='customerABC', pnRegistered=false, timestamp=0})\n";
+    event = (StaticLoggingEvent)decoder.decode(input);
+    assertEquals("123abc", event.getMDCPropertyMap().get("SID"));
+    assertEquals("456xyz", event.getMDCPropertyMap().get("CID"));
+
+    decoder.setLayoutPattern("%d{HH:mm:ss.SSS} [%thread] %-5level %logger{35} ID:%X{} - %msg%n");
+    input = "20:44:20.120 [JGroups-Executor-17] INFO c._.u.s.xmpp.server.XMPPConnection ID:SID=123abc, CID=456xyz - START handlePresence(PbxUserPresence{extension='1234', message='', status=3, pbxId='customerABC', pnRegistered=false, timestamp=0})\n";
+    event = (StaticLoggingEvent)decoder.decode(input);
+    assertEquals("123abc", event.getMDCPropertyMap().get("SID"));
+    assertEquals("456xyz", event.getMDCPropertyMap().get("CID"));
   }
 
   private String getMessage(String message) {


### PR DESCRIPTION
The current code parses the value of MDC property `%X` or `%mdc` as CSV key-values, e.g., `key1=val1,key2=value2`. But in logback, you can specify the key (e.g., `%X{key1}` or `%X{key1:-defaultVal}`, then the log only contains the value.

This modifies MDCRegexConverter and Decoder to parse the MDC property with key properly.