### PR TITLE
fix logback date parser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,8 +142,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.5.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 

--- a/src/main/java/ch/qos/logback/core/pattern/parser2/DatePatternInfo.java
+++ b/src/main/java/ch/qos/logback/core/pattern/parser2/DatePatternInfo.java
@@ -12,24 +12,29 @@
  */
 package ch.qos.logback.core.pattern.parser2;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import ch.qos.logback.core.CoreConstants;
+
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Auxiliary pattern info for a date conversion-word (%d) -- specifically the date format.
  */
 public class DatePatternInfo extends PatternInfo {
-  private DateFormat dateFormat;
+  public static final DateTimeFormatter ISO8601_FORMATTER =
+      DateTimeFormatter.ofPattern(CoreConstants.ISO8601_PATTERN).withZone(ZoneOffset.UTC);
+
+  private DateTimeFormatter dateFormat;
 
   public DatePatternInfo() {
-    dateFormat = SimpleDateFormat.getDateInstance();
+    dateFormat = ISO8601_FORMATTER;
   }
 
   /**
    * Gets the date format
    * @return the date format
    */
-  public DateFormat getDateFormat() {
+  public DateTimeFormatter getDateFormat() {
     return dateFormat;
   }
 
@@ -37,7 +42,7 @@ public class DatePatternInfo extends PatternInfo {
    * Sets the date format
    * @param dateFormat desired date format
    */
-  public void setDateFormat(DateFormat dateFormat) {
+  public void setDateFormat(DateTimeFormatter dateFormat) {
     this.dateFormat = dateFormat;
   }
 }


### PR DESCRIPTION
When logback is configured to only log the timestamp without date (e.g., 12:34:56), logback parser parses it as the time of 1970/01/01. This fixes it by using today's year/month/day when parsing the timestamp-only string.

Also switch to Java 8's new Date/Time API.