### PR TITLE
Support custom timezone

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>ch.qos.logback</groupId>
   <artifactId>logback-decoder</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.1.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>logback-decoder</name>
   <description>The logback log file decoder</description>

--- a/src/main/java/ch/qos/logback/core/pattern/parser2/DatePatternInfo.java
+++ b/src/main/java/ch/qos/logback/core/pattern/parser2/DatePatternInfo.java
@@ -14,6 +14,7 @@ package ch.qos.logback.core.pattern.parser2;
 
 import ch.qos.logback.core.CoreConstants;
 
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
@@ -25,6 +26,7 @@ public class DatePatternInfo extends PatternInfo {
       DateTimeFormatter.ofPattern(CoreConstants.ISO8601_PATTERN).withZone(ZoneOffset.UTC);
 
   private DateTimeFormatter dateFormat;
+  private ZoneId timezone = ZoneOffset.UTC;
 
   public DatePatternInfo() {
     dateFormat = ISO8601_FORMATTER;
@@ -44,5 +46,13 @@ public class DatePatternInfo extends PatternInfo {
    */
   public void setDateFormat(DateTimeFormatter dateFormat) {
     this.dateFormat = dateFormat;
+  }
+
+  public void setTimezone(ZoneId timezone) {
+    this.timezone = timezone;
+  }
+
+  public ZoneId getTimezone() {
+    return timezone;
   }
 }

--- a/src/main/java/ch/qos/logback/core/pattern/parser2/DatePatternInfo.java
+++ b/src/main/java/ch/qos/logback/core/pattern/parser2/DatePatternInfo.java
@@ -23,10 +23,10 @@ import java.time.format.DateTimeFormatter;
  */
 public class DatePatternInfo extends PatternInfo {
   public static final DateTimeFormatter ISO8601_FORMATTER =
-      DateTimeFormatter.ofPattern(CoreConstants.ISO8601_PATTERN).withZone(ZoneOffset.UTC);
+      DateTimeFormatter.ofPattern(CoreConstants.ISO8601_PATTERN);
 
   private DateTimeFormatter dateFormat;
-  private ZoneId timezone = ZoneOffset.UTC;
+  private ZoneId timeZone = ZoneOffset.UTC;
 
   public DatePatternInfo() {
     dateFormat = ISO8601_FORMATTER;
@@ -48,11 +48,11 @@ public class DatePatternInfo extends PatternInfo {
     this.dateFormat = dateFormat;
   }
 
-  public void setTimezone(ZoneId timezone) {
-    this.timezone = timezone;
+  public void setTimeZone(ZoneId timeZone) {
+    this.timeZone = timeZone;
   }
 
-  public ZoneId getTimezone() {
-    return timezone;
+  public ZoneId getTimeZone() {
+    return timeZone;
   }
 }

--- a/src/main/java/ch/qos/logback/core/pattern/parser2/PatternParser.java
+++ b/src/main/java/ch/qos/logback/core/pattern/parser2/PatternParser.java
@@ -97,7 +97,7 @@ public class PatternParser {
       return DatePatternInfo.ISO8601_FORMATTER;
     }
 
-    ZoneId tz = ZoneOffset.UTC;
+    ZoneId tz = null;
 
     // Parse the last option in the conversion pattern as a time zone.
     // Make sure the comma is not escaped/quoted.
@@ -112,7 +112,7 @@ public class PatternParser {
       String tzStr = option.substring(idx + 1).trim();
       if (!tzStr.startsWith("SSS")) {
         option = option.substring(0, idx);
-        tz = ZoneId.of(tzStr);
+        tz = ZoneId.of(tzStr, ZoneId.SHORT_IDS);
         if (!tz.getId().equalsIgnoreCase(tzStr)) {
           logger().warn("Time zone (\"{}\") defaulting to \"{}\".", tzStr, tz.getId());
         }
@@ -124,7 +124,10 @@ public class PatternParser {
       option = option.substring(1, option.length() - 1);
     }
 
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern(option).withZone(tz);
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern(option);
+    if (tz != null) {
+      formatter = formatter.withZone(tz);
+    }
 
     return formatter;
   }

--- a/src/main/java/ch/qos/logback/decoder/DateParser.java
+++ b/src/main/java/ch/qos/logback/decoder/DateParser.java
@@ -12,13 +12,11 @@
  */
 package ch.qos.logback.decoder;
 
-import java.text.ParseException;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
-import java.util.Date;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,18 +41,20 @@ public class DateParser implements FieldCapturer<IStaticLoggingEvent> {
       DatePatternInfo dpi = (DatePatternInfo)info;
       try {
         DateTimeFormatter dtf = dpi.getDateFormat();
+        ZoneId timeZone = dpi.getTimeZone();
+        String datePattern = dpi.getOption().toLowerCase();
 
         // If the date pattern only contains time, use the today's year/month/day when parsing the input string.
-        if (dtf != DatePatternInfo.ISO8601_FORMATTER
-            && !dpi.getOption().toLowerCase().contains("d")) {
-          ZoneId zoneId = dtf.getZone() == null ? dpi.getTimezone() : dtf.getZone();
-          LocalDate today = LocalDate.now(zoneId);
+        if (dtf != DatePatternInfo.ISO8601_FORMATTER && !datePattern.contains("d")) {
+          LocalDate today = LocalDate.now(timeZone);
           dtf = new DateTimeFormatterBuilder().append(dtf)
               .parseDefaulting(ChronoField.YEAR, today.getYear())
               .parseDefaulting(ChronoField.MONTH_OF_YEAR, today.getMonthValue())
               .parseDefaulting(ChronoField.DAY_OF_MONTH, today.getDayOfMonth())
-              .toFormatter();
-          dtf = dtf.withZone(zoneId);
+              .toFormatter().withZone(timeZone);
+        } else if (dtf.getZone() == null && !datePattern.contains("z") && !datePattern.contains("x")) {
+          // if TimeZone is not specified in the pattern format, use the one provided.
+          dtf = dtf.withZone(timeZone);
         }
 
         ZonedDateTime date = ZonedDateTime.parse(fieldAsStr, dtf);

--- a/src/main/java/ch/qos/logback/decoder/DateParser.java
+++ b/src/main/java/ch/qos/logback/decoder/DateParser.java
@@ -47,8 +47,8 @@ public class DateParser implements FieldCapturer<IStaticLoggingEvent> {
         // If the date pattern only contains time, use the today's year/month/day when parsing the input string.
         if (dtf != DatePatternInfo.ISO8601_FORMATTER
             && !dpi.getOption().toLowerCase().contains("d")) {
-          ZoneId zoneId = dtf.getZone();
-          LocalDate today = LocalDate.now(zoneId == null ? ZoneOffset.UTC: zoneId);
+          ZoneId zoneId = dtf.getZone() == null ? dpi.getTimezone() : dtf.getZone();
+          LocalDate today = LocalDate.now(zoneId);
           dtf = new DateTimeFormatterBuilder().append(dtf)
               .parseDefaulting(ChronoField.YEAR, today.getYear())
               .parseDefaulting(ChronoField.MONTH_OF_YEAR, today.getMonthValue())

--- a/src/main/java/ch/qos/logback/decoder/Decoder.java
+++ b/src/main/java/ch/qos/logback/decoder/Decoder.java
@@ -40,7 +40,6 @@ public abstract class Decoder {
   private Pattern regexPattern;
   private String layoutPattern;
   private List<PatternInfo> patternInfo;
-  private ZoneId timezone = ZoneOffset.UTC;
 
   /**
    * Constructs a {@code Decoder}
@@ -66,10 +65,6 @@ public abstract class Decoder {
     this.layoutPattern = layoutPattern;
   }
 
-  public void setTimezone(ZoneId timezone) {
-    this.timezone = timezone;
-  }
-
   /**
    * Gets the layout pattern used for decoding
    *
@@ -87,7 +82,10 @@ public abstract class Decoder {
    * if line cannot be decoded
    */
   public ILoggingEvent decode(String inputLine) {
+    return decode(inputLine, ZoneOffset.UTC);
+  }
 
+  public ILoggingEvent decode(String inputLine, ZoneId timeZone) {
     StaticLoggingEvent event = null;
     Matcher matcher = regexPattern.matcher(inputLine);
     Map<String, String> mdcProperties = null;
@@ -133,7 +131,7 @@ public abstract class Decoder {
           if (parser == null) {
             logger.warn("No decoder for [{}, {}]", pattName, field);
           } else {
-            parser.captureField(event, field, getPatternInfo(patternIndex, pattName));
+            parser.captureField(event, field, getPatternInfo(patternIndex, pattName, timeZone));
           }
         }
 
@@ -155,7 +153,7 @@ public abstract class Decoder {
    * @param fieldName the name of the sub-pattern
    * @return the pattern info or {@code null} if not found
    */
-  private PatternInfo getPatternInfo(int patternIndex, String fieldName) {
+  private PatternInfo getPatternInfo(int patternIndex, String fieldName, ZoneId timeZone) {
     PatternInfo inf = patternInfo.get(patternIndex);
     if (inf != null) {
 
@@ -172,7 +170,7 @@ public abstract class Decoder {
       }
 
       if (inf instanceof DatePatternInfo) {
-        ((DatePatternInfo) inf).setTimezone(timezone);
+        ((DatePatternInfo) inf).setTimeZone(timeZone);
       }
     }
     return inf;

--- a/src/main/java/ch/qos/logback/decoder/Decoder.java
+++ b/src/main/java/ch/qos/logback/decoder/Decoder.java
@@ -12,11 +12,14 @@
  */
 package ch.qos.logback.decoder;
 
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import ch.qos.logback.core.pattern.parser2.DatePatternInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +40,7 @@ public abstract class Decoder {
   private Pattern regexPattern;
   private String layoutPattern;
   private List<PatternInfo> patternInfo;
+  private ZoneId timezone = ZoneOffset.UTC;
 
   /**
    * Constructs a {@code Decoder}
@@ -60,6 +64,10 @@ public abstract class Decoder {
       patternInfo = null;
     }
     this.layoutPattern = layoutPattern;
+  }
+
+  public void setTimezone(ZoneId timezone) {
+    this.timezone = timezone;
   }
 
   /**
@@ -161,6 +169,10 @@ public abstract class Decoder {
               new Object[] { patternIndex, fieldName, infName });
 
         inf = null;
+      }
+
+      if (inf instanceof DatePatternInfo) {
+        ((DatePatternInfo) inf).setTimezone(timezone);
       }
     }
     return inf;

--- a/src/test/java/ch/qos/logback/decoder/DateDecoderTest.java
+++ b/src/test/java/ch/qos/logback/decoder/DateDecoderTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.TimeZone;
@@ -89,6 +90,12 @@ public class DateDecoderTest extends DecoderTest {
     final String FORMAT   = "yyyy-MM-dd hh:mm:ss.SSSa";
     final String INPUT    = "2013-06-15 03:55:00.123PM";
     assertThatDateDecoded(TIMEZONE, FORMAT, INPUT);
+  }
+
+  @Test
+  public void testTimezone() throws ParseException {
+
+
   }
 
   private void assertThatDateDecoded(String timeZoneName, String format, String input) throws ParseException {

--- a/src/test/java/ch/qos/logback/decoder/DateDecoderTest.java
+++ b/src/test/java/ch/qos/logback/decoder/DateDecoderTest.java
@@ -18,9 +18,7 @@ import org.junit.Test;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
+import java.time.*;
 import java.util.Calendar;
 import java.util.TimeZone;
 
@@ -93,9 +91,60 @@ public class DateDecoderTest extends DecoderTest {
   }
 
   @Test
-  public void testTimezone() throws ParseException {
+  public void testTimezone() {
+    String dateString = "2018-02-28 12:00:00,000";
+    decoder.setLayoutPattern("%d");
+    LocalDateTime dateTime =
+        LocalDateTime.of(2018, 2, 28, 12, 0, 0, 0);
 
+    ILoggingEvent event = decoder.decode(dateString);
+    assertEquals(ZonedDateTime.of(dateTime, ZoneOffset.UTC).toInstant().toEpochMilli(), event.getTimeStamp());
 
+    ZoneId tz = ZoneOffset.ofHours(8);
+    event = decoder.decode(dateString, tz);
+    assertEquals(ZonedDateTime.of(dateTime, tz).toInstant().toEpochMilli(), event.getTimeStamp());
+
+    // verify that Daylight Saving Time is handled properly
+    String summerDateString = "2018-07-08 12:00:00,000";
+    LocalDateTime summerDateTime =
+        LocalDateTime.of(2018, 7, 8, 12, 0, 0, 0);
+
+    tz = ZoneId.of("America/Los_Angeles");
+    event = decoder.decode(dateString, tz);
+    assertEquals(ZonedDateTime.of(dateTime, ZoneOffset.ofHours(-8)).toInstant().toEpochMilli(), event.getTimeStamp());
+    event = decoder.decode(summerDateString, tz);
+    assertEquals(ZonedDateTime.of(summerDateTime, ZoneOffset.ofHours(-7)).toInstant().toEpochMilli(), event.getTimeStamp());
+
+    tz = ZoneId.of("PST", ZoneId.SHORT_IDS);
+    event = decoder.decode(dateString, tz);
+    assertEquals(ZonedDateTime.of(dateTime, ZoneOffset.ofHours(-8)).toInstant().toEpochMilli(), event.getTimeStamp());
+    event = decoder.decode(summerDateString, tz);
+    assertEquals(ZonedDateTime.of(summerDateTime, ZoneOffset.ofHours(-7)).toInstant().toEpochMilli(), event.getTimeStamp());
+
+    // if timezone is specified in the pattern, then honor it.
+    decoder.setLayoutPattern("%d{\"" + CoreConstants.ISO8601_PATTERN + "\", Asia/Tokyo}");
+    ZoneId jst = ZoneId.of("JST", ZoneId.SHORT_IDS);
+    event = decoder.decode(dateString);
+    assertEquals(ZonedDateTime.of(dateTime, jst).toInstant().toEpochMilli(), event.getTimeStamp());
+    event = decoder.decode(dateString, tz);
+    assertEquals(ZonedDateTime.of(dateTime, jst).toInstant().toEpochMilli(), event.getTimeStamp());
+
+    decoder.setLayoutPattern("%d{\"" + CoreConstants.ISO8601_PATTERN + "\", JST}");
+    event = decoder.decode(dateString);
+    assertEquals(ZonedDateTime.of(dateTime, jst).toInstant().toEpochMilli(), event.getTimeStamp());
+    event = decoder.decode(dateString, tz);
+    assertEquals(ZonedDateTime.of(dateTime, jst).toInstant().toEpochMilli(), event.getTimeStamp());
+
+    // if timezone is provided in the timestamp, honor it.
+    String dateStringWithTZ = "2018-02-28T12:00:00.000-0700";
+    decoder.setLayoutPattern("%d{\"yyyy-MM-dd'T'HH:mm:ss.SSSZ\"}");
+    event = decoder.decode(dateStringWithTZ);
+    assertEquals(ZonedDateTime.of(dateTime, ZoneOffset.ofHours(-7)).toInstant().toEpochMilli(), event.getTimeStamp());
+
+    dateStringWithTZ = "2018-02-28 12:00:00.000 JST";
+    decoder.setLayoutPattern("%d{\"yyyy-MM-dd HH:mm:ss.SSS z\"}");
+    event = decoder.decode(dateStringWithTZ);
+    assertEquals(ZonedDateTime.of(dateTime, ZoneOffset.ofHours(9)).toInstant().toEpochMilli(), event.getTimeStamp());
   }
 
   private void assertThatDateDecoded(String timeZoneName, String format, String input) throws ParseException {


### PR DESCRIPTION
Adding `Decoder.decode(String inputLine, ZoneId timeZone)` method, which uses the provided timeZone if the pattern string or the timestamp in the inputLine doesn't contain timestamp.

Added unit tests to verify that timeZone param is used iff the pattern string or the timestamp in the inputLine doesn't contain timestamp. Also verified that Daylight Saving Time is supported properly.