### PR TITLE
EN-1093 support non-alnum char in MDC key,  EN-737 throw proper exception for unknown pattern

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>ch.qos.logback</groupId>
   <artifactId>logback-decoder</artifactId>
-  <version>0.1.2-SNAPSHOT</version>
+  <version>0.1.3-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>logback-decoder</name>
   <description>The logback log file decoder</description>

--- a/src/main/java/ch/qos/logback/core/pattern/parser2/PatternParser.java
+++ b/src/main/java/ch/qos/logback/core/pattern/parser2/PatternParser.java
@@ -162,15 +162,19 @@ public class PatternParser {
       int nextPos        = minX(group.end(), m.start(OPTION));
       CapturedText opt   = getEnclosedText(layoutPattern, nextPos, '{', '}', true);
       int end            = minX(opt.end(), m.end());
+      String name = m.group(NAME);
+      if (name == null) {
+        throw new IllegalArgumentException("Unknown pattern name at " + start + " in the pattern: " + layoutPattern);
+      }
 
-      boolean isDate = PatternNames.getFullName(m.group(NAME)).equals("date");
+      boolean isDate = "date".equals(PatternNames.getFullName(name));
       PatternInfo inf = isDate ? new DatePatternInfo() : new PatternInfo();
 
       inf.setOriginal(m.group(0))
           .setStart(start)
           .setEnd(end)
           .setGroup(group.value())
-          .setName(m.group(NAME))
+          .setName(name)
           .setOption(opt.value())
           .setFormatModifier(m.group(FORMAT));
 

--- a/src/main/java/ch/qos/logback/decoder/regex/MDCRegexConverter.java
+++ b/src/main/java/ch/qos/logback/decoder/regex/MDCRegexConverter.java
@@ -12,16 +12,19 @@
  */
 package ch.qos.logback.decoder.regex;
 
-import java.io.InputStream;
-
-import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.pattern.DynamicConverter;
 import ch.qos.logback.decoder.PatternNames;
+import org.apache.commons.lang3.RandomStringUtils;
+
+import java.io.InputStream;
+import java.util.regex.Pattern;
 
 /**
  * Converts a MDC pattern into a regular expression
  */
 public class MDCRegexConverter extends DynamicConverter<InputStream> {
+  private static final Pattern NON_ALNUM = Pattern.compile("[^a-zA-Z0-9]");
+
   private String key = null;
 
   @Override
@@ -29,6 +32,16 @@ public class MDCRegexConverter extends DynamicConverter<InputStream> {
     key = getFirstOption();
     if (key != null && key.indexOf(":-") > 0) {
       key = key.substring(0, key.indexOf(":-"));
+    }
+
+    // if key contains non alnum char, use random generated key instead.
+    if (key != null && NON_ALNUM.matcher(key).find()) {
+      String newKey;
+      do {
+        newKey = "KEY" + RandomStringUtils.randomAlphanumeric(5);
+      } while (getContext().getProperty(newKey) != null);
+      getContext().putProperty(newKey, key);
+      key = newKey;
     }
   }
 

--- a/src/main/java/ch/qos/logback/decoder/regex/PatternLayoutRegexUtil.java
+++ b/src/main/java/ch/qos/logback/decoder/regex/PatternLayoutRegexUtil.java
@@ -12,13 +12,13 @@
  */
 package ch.qos.logback.decoder.regex;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import ch.qos.logback.core.ContextBase;
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.pattern.PatternLayoutBase;
 import ch.qos.logback.core.pattern.parser2.PatternParser;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Utility to convert a layout pattern into a regular expression
@@ -66,6 +66,10 @@ public class PatternLayoutRegexUtil {
     patt = patt.replaceAll("\\s+", "\\\\s+");
 
     return patt;
+  }
+
+  public Map<String, String> getProperties() {
+    return converter.getContext().getCopyOfPropertyMap();
   }
 }
 

--- a/src/test/java/ch/qos/logback/core/pattern/parser2/PatternParserTest.java
+++ b/src/test/java/ch/qos/logback/core/pattern/parser2/PatternParserTest.java
@@ -244,4 +244,9 @@ public class PatternParserTest {
     final String PATT = "{%d} %replace(%logger [%thread]){'\\d{14,16}', 'XXXX'} [%level] - %msg%n";
     assertEquals(PATT, PatternParser.unescapeRegexCharsInPattern(PATT));
   }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testUnsupportedPatternName()  {
+    PatternParser.parse("%wEx");
+  }
 }

--- a/src/test/java/ch/qos/logback/decoder/MessageDecoderTest.java
+++ b/src/test/java/ch/qos/logback/decoder/MessageDecoderTest.java
@@ -99,6 +99,17 @@ public class MessageDecoderTest extends DecoderTest {
     assertTrue(event.getMDCPropertyMap().isEmpty());
     assertTrue(event.mdcPropertyOffsets.isEmpty());
 
+    // key contains dash '_'
+    decoder.setLayoutPattern("%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{request_id}] - %msg%n");
+    input = "2018-02-04 12:00:00.000 [123xyz] - test test test\n";
+    event = (StaticLoggingEvent)decoder.decode(input);
+    assertEquals("123xyz", event.getMDCPropertyMap().get("request_id"));
+
+    // key contains dash '-'
+    decoder.setLayoutPattern("%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{request-id}] - %msg%n");
+    input = "2018-02-04 12:00:00.000 [123xyz] - test test test\n";
+    event = (StaticLoggingEvent)decoder.decode(input);
+    assertEquals("123xyz", event.getMDCPropertyMap().get("request-id"));
   }
 
   private String getMessage(String message) {


### PR DESCRIPTION
EN-1093: logback-decoder uses named group to capture MDC, but group name can only contain alnum char, so it fails to parse a layout if it contains MDC with non-alnum char (e.g., `request-id`).

This PR fixes it by using a random string as group name in the Regex and storing a mapping from the random string to the original key in the context.

Also fixes EN-737 to throw IllegalArgumentException instead of NPE when a logback layout contains unknown pattern name.