### PR TITLE
Our parsers use DateTimeFormatter to parse a timestamp. DateTimeForma…

### DIFF
--- a/src/main/java/ch/qos/logback/decoder/Decoder.java
+++ b/src/main/java/ch/qos/logback/decoder/Decoder.java
@@ -12,20 +12,16 @@
  */
 package ch.qos.logback.decoder;
 
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.pattern.parser2.PatternInfo;
 import ch.qos.logback.core.pattern.parser2.PatternParser;
 import ch.qos.logback.decoder.regex.PatternLayoutRegexUtil;
+
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * A {@code Decoder} parses information from a log string and produces an
@@ -47,9 +43,6 @@ public class Decoder {
     this(layoutPattern, ZoneOffset.UTC);
   }
 
-
-
-
   public Decoder(String layoutPattern, ZoneId defaultTimeZone) {
     if (layoutPattern == null) {
       throw new IllegalArgumentException("layoutPattern cannot be null");
@@ -64,11 +57,6 @@ public class Decoder {
 
     PatternLayoutRegexUtil util = new PatternLayoutRegexUtil();
     String regex = util.toRegex(layoutPattern) + "$";
-
-    //pad modifier on the left with spaces to a width of 3 or more, Matches between 3 to 50 e.g. p{30}\d{1}.
-    regex = regex.replaceAll("p[{][3-50][}]\\\\d[{][1][}]", "\\\\s+\\\\d{1,2}");
-    //pad modifier on the left with spaces to a width of 1 or 2
-    regex = regex.replaceAll("p[{][1-2][}]\\\\d[{][1][}]", "\\\\s?\\\\d{1,2}");
     this.regexPattern = Pattern.compile(regex);
 
     namedGroups = new ArrayList<>();

--- a/src/main/java/ch/qos/logback/decoder/Decoder.java
+++ b/src/main/java/ch/qos/logback/decoder/Decoder.java
@@ -12,16 +12,20 @@
  */
 package ch.qos.logback.decoder;
 
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.pattern.parser2.PatternInfo;
 import ch.qos.logback.core.pattern.parser2.PatternParser;
 import ch.qos.logback.decoder.regex.PatternLayoutRegexUtil;
-
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * A {@code Decoder} parses information from a log string and produces an
@@ -43,6 +47,9 @@ public class Decoder {
     this(layoutPattern, ZoneOffset.UTC);
   }
 
+
+
+
   public Decoder(String layoutPattern, ZoneId defaultTimeZone) {
     if (layoutPattern == null) {
       throw new IllegalArgumentException("layoutPattern cannot be null");
@@ -57,6 +64,11 @@ public class Decoder {
 
     PatternLayoutRegexUtil util = new PatternLayoutRegexUtil();
     String regex = util.toRegex(layoutPattern) + "$";
+
+    //pad modifier on the left with spaces to a width of 3 or more, Matches between 3 to 50 e.g. p{30}\d{1}.
+    regex = regex.replaceAll("p[{][3-50][}]\\\\d[{][1][}]", "\\\\s+\\\\d{1,2}");
+    //pad modifier on the left with spaces to a width of 1 or 2
+    regex = regex.replaceAll("p[{][1-2][}]\\\\d[{][1][}]", "\\\\s?\\\\d{1,2}");
     this.regexPattern = Pattern.compile(regex);
 
     namedGroups = new ArrayList<>();

--- a/src/main/java/ch/qos/logback/decoder/regex/PatternLayoutRegexUtil.java
+++ b/src/main/java/ch/qos/logback/decoder/regex/PatternLayoutRegexUtil.java
@@ -12,13 +12,13 @@
  */
 package ch.qos.logback.decoder.regex;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import ch.qos.logback.core.ContextBase;
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.pattern.PatternLayoutBase;
 import ch.qos.logback.core.pattern.parser2.PatternParser;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Utility to convert a layout pattern into a regular expression
@@ -62,6 +62,11 @@ public class PatternLayoutRegexUtil {
     String conversion = converter.doLayout(null);
     String patt = PatternParser.switchEscapeSequenceToSlashes(conversion);
 
+
+    //pad modifier on the left with spaces to a width of 3 or more, Matches between 3 to 50 e.g. p{30}\d{1}.
+    patt = patt.replaceAll("p[{][3-50][}]\\\\d[{][1][}]", "\\\\s+\\\\d{1,2}");
+    //pad modifier on the left with spaces to a width of 1 or 2
+    patt = patt.replaceAll("p[{][1-2][}]\\\\d[{][1][}]", "\\\\s?\\\\d{1,2}");
     // Allow flexible spacing
     patt = patt.replaceAll("\\s+", "\\\\s+");
 

--- a/src/main/java/ch/qos/logback/decoder/regex/PatternLayoutRegexUtil.java
+++ b/src/main/java/ch/qos/logback/decoder/regex/PatternLayoutRegexUtil.java
@@ -63,8 +63,8 @@ public class PatternLayoutRegexUtil {
     String patt = PatternParser.switchEscapeSequenceToSlashes(conversion);
 
 
-    //pad modifier on the left with spaces to a width of 3 or more, Matches between 3 to 50 e.g. p{30}\d{1}.
-    patt = patt.replaceAll("p[{][3-50][}]\\\\d[{][1][}]", "\\\\s+\\\\d{1,2}");
+    //pad modifier on the left with spaces to a width of 3 or more, Matches between 3 to 59 e.g. p{30}\d{1}.
+    patt = patt.replaceAll("p[{]([3-9]|[1-5][0-9])[}]\\\\d[{][1][}]", "\\\\s+\\\\d{1,2}");
     //pad modifier on the left with spaces to a width of 1 or 2
     patt = patt.replaceAll("p[{][1-2][}]\\\\d[{][1][}]", "\\\\s?\\\\d{1,2}");
     // Allow flexible spacing

--- a/src/test/java/ch/qos/logback/decoder/DateDecoderTest.java
+++ b/src/test/java/ch/qos/logback/decoder/DateDecoderTest.java
@@ -97,6 +97,12 @@ public class DateDecoderTest {
 		dateTime = LocalDateTime.of(2019, 11, 14, 04, 28, 21, 0);
 		assertEquals(ZonedDateTime.of(dateTime, ZoneOffset.UTC).toInstant().toEpochMilli(), event.getTimeStamp());
 
+		decoder = new Decoder("%d{\"yyyy MMM ppd pppppH:mm:ss\"}");
+		String dateStringWithMultipleSpace = "2019 Nov 14     4:28:21";
+		event = decoder.decode(dateStringWithMultipleSpace);
+		dateTime = LocalDateTime.of(2019, 11, 14, 04, 28, 21, 0);
+		assertEquals(ZonedDateTime.of(dateTime, ZoneOffset.UTC).toInstant().toEpochMilli(), event.getTimeStamp());
+
 	}
 
   @Test
@@ -138,6 +144,7 @@ public class DateDecoderTest {
     var isoFormat = year + "-" + month + "-" + day + "T03:55:00";
     var expected = ZonedDateTime.parse(isoFormat, DateTimeFormatter.ISO_DATE_TIME.withZone(ZoneOffset.UTC));
     assertThatDateDecoded(TIMEZONE, FORMAT, INPUT, expected);
+
   }
 
   @Test


### PR DESCRIPTION
…tter supports “pad modifier” p, which can be used to add extra space for padding. e.g., ppd will format the day 6 as  6 with an extra space. However, the decoders used in Log4jParser and LogbackParser don’t support the pad modifier.

    This fix is to improve the logback decoders to support the pad modifier so that they can parse [space]6 with the format ppd.

    DatePattern:       "yyyy-ppM-dd'T'HH:mm:ss.SSSZ"
    DateString:        "2018- 2-28T12:00:00.000-0700"
    Decoded Date:      "2018-02-28T12:00-07:00"